### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/silrenan/0xbitdrain/security/code-scanning/1](https://github.com/silrenan/0xbitdrain/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for each job. Based on the workflow's functionality:
- The `test` job does not interact with the repository, so it only needs `contents: read` permissions to access files.
- The `lint` job also does not modify the repository, so it can use the same `contents: read` permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more concise and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
